### PR TITLE
Update 2.use-docker-to-deploy-oceanbase-database.md

### DIFF
--- a/zh-CN/2.quick-start/2.use-docker-to-deploy-oceanbase-database.md
+++ b/zh-CN/2.quick-start/2.use-docker-to-deploy-oceanbase-database.md
@@ -6,7 +6,7 @@
 
 在部署 [oceanbase-ce](https://hub.docker.com/r/oceanbase/oceanbase-ce) 镜像之前，您需要确认以下信息：
 
-* 确保您的机器至少提供 2 核 8GB 以上的可用资源。
+* 确保您的机器至少提供 2 核 10GB 以上的可用资源。
 
 * 您的机器已安装最新版的 Docker，参考 [Docker 文档](https://docs.docker.com/get-docker/)。
 


### PR DESCRIPTION
the minimum memory limit is 10G now. 8G docker should be build by dockerfile in mini directory