### PR TITLE
[字典视图]章节一些错误修改

### DIFF
--- a/zh-CN/15.oceanbase-database-overview/6.database-objects/6.mysql-mode-system-views/1.mysql-mode-dictionary-views.md
+++ b/zh-CN/15.oceanbase-database-overview/6.database-objects/6.mysql-mode-system-views/1.mysql-mode-dictionary-views.md
@@ -1,20 +1,20 @@
 字典视图 
 =========================
 
-OceanBase 数据库 MySQL 模式下拥有数据字典，数据字典表受到保护，只能使用 DEBUG 调试获取到相关信息。字典视图是用来访问数据字典的，在 MySQL模式下支持通过 INFORMATION_SCHEMA 表和 SHOW 语句访问存储在数据字典表中的数据。
+OceanBase 数据库 MySQL 模式下拥有数据字典，数据字典表受到保护，只能使用 DEBUG 调试获取到相关信息。字典视图是用来访问数据字典的，在 MySQL 模式下支持通过查询 information_schema 数据库下的视图或使用 SHOW 语句访问存储在数据字典表中的数据。
 
 字典视图的组成 
 ----------------------------
 
 OceanBase 数据库 MySQL 模式下的字典视图包含 `information_schema.*` 相关视图、`CDB_` 前缀视图以及 `mysql.*` 视图。
 
-### 带有 INFORMATION_SCHEMA 前缀的视图 
+### 带有 information_schema 前缀的视图 
 
-INFORMATION_SCHEMA 提供对 MySQL 租户中数据库元数据（例如数据库或表的名称、列的数据类型或访问权限）的访问。 有时也叫做数据字典或系统目录。INFORMATION_SCHEMA 是每个 MySQL 租户中的一个 Database/Schema，用于存储有关 MySQL 租户维护的所有其他数据库的信息。INFORMATION_SCHEMA 数据库包含几个只读表。它们实际上是视图，而不是基表。
+information_schema 提供对 MySQL 租户中数据库元数据（例如数据库或表的名称、列的数据类型或访问权限）的访问。 有时也叫做数据字典或系统目录。information_schema 是每个 MySQL 租户中的一个 Database/Schema，用于存储有关 MySQL 租户维护的所有其他数据库的信息。information_schema 数据库包含几个只读表。它们实际上是视图，而不是基表。
 
 ### 带有 mysql 前缀的视图 
 
-带有 `mysql` 前缀的视图都是系统视图，包含存储 OceanBase 数据库 MySQL 模式下服务器运行时所需信息的表。一般地，带 `mysql` 前缀的视图包含存储数据库对象元数据的数据字典表和用于其他操作目的的系统表。OceanBase 数据库兼容了部分 `mysql` 前缀的视图，例如 `help_*` 视图包含了服务器端的一些帮助信息，`time_zone*` 记录了时区相关的信息，`USER` 视图和 DB 视图记录了用户权限相关的一些信息。
+带有 `mysql` 前缀的视图都是系统视图，包含存储 OceanBase 数据库 MySQL 模式下服务器运行时所需信息的表。一般地，带 `mysql` 前缀的视图包含存储数据库对象元数据的数据字典表和用于其他操作目的的系统表。OceanBase 数据库兼容了部分 `mysql` 前缀的视图，例如 `time_zone*` 记录了时区相关的信息，`user` 视图和 `db` 视图记录了用户权限相关的一些信息。
 
 ### 带有 oceanbase.CDB 前缀的视图 
 


### PR DESCRIPTION
1.措辞修改；

2.大小写问题统一，数据库中大小写是区分的，比如CDB确实是大写，information_schema确实是小写，所以此处做了统一；

3.去掉 help_*的例子，因为数据库中没有这个视图，如下：
<img width="410" alt="image" src="https://user-images.githubusercontent.com/2404284/165667143-e743d6aa-f42c-4998-ab03-8d607b8beacc.png">
