### PR TITLE
[内存相关内部表]章节视图不存在问题一处

### DIFF
--- a/zh-CN/15.oceanbase-database-overview/14.observer-architecture/5.oceanbase-database-overview-memory-management/3.memory-related-internal-tables.md
+++ b/zh-CN/15.oceanbase-database-overview/14.observer-architecture/5.oceanbase-database-overview-memory-management/3.memory-related-internal-tables.md
@@ -4,7 +4,6 @@ OceanBase 数据库支持通过内部表来查看内存的使用情况。
 
 |                  视图                  | 描述 |   |
 |--------------------------------------|----|---|
-| __all_virtual_tenant_ctx_memory_info | context 级别的统计信息（context 是面向开发者的概念），它是 2M 粒度的统计。 ||
 | __all_virtual_memory_info            | OBServer 内存标签的统计信息。 ||
 | __all_virtual_tenant_memstore_info   | MemStore 统计信息。 ||
 | __all_virtual_kvcache_info           | kvcache 统计信息。 ||


### PR DESCRIPTION
该视图在代码和 SQL 命令行中均查询不到，参考下图：

<img width="1217" alt="image" src="https://user-images.githubusercontent.com/2404284/168395231-dcc6653e-6469-433b-9681-c107b13ffc81.png">
