### PR TITLE
[如何贡献]章节修改错别字

### DIFF
--- a/zh-CN/16.community-contribution/1.become-a-contributor.md
+++ b/zh-CN/16.community-contribution/1.become-a-contributor.md
@@ -6,12 +6,13 @@ OceanBase 数据库是一个开源的项目。欢迎您贡献代码或文档。�
 开始之前 
 -------------------------
 
-欢迎您为 OceanBase 数据库贡献代码或文档。在您开始贡献之前，您需要签署贡献者许可协议（Contributor Licence Agreement，简称 CLA）。详细信息，参考 [什么是 CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement)。点击 [OceaBase CLA](https://cla-assistant.io/oceanbase/oceanbase?pullRequest=108)，点击 **Sign in with GitHub to agree** 按钮签署协议。
+欢迎您为 OceanBase 数据库贡献代码或文档。在您开始贡献之前，您需要签署贡献者许可协议（Contributor License Agreement，简称 CLA）。详细信息，参考 [什么是 CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement)。点击 [OceanBase CLA](https://cla-assistant.io/oceanbase/oceanbase?pullRequest=108)，点击 **Sign in with GitHub to agree** 按钮签署协议。
 
 贡献指南 
 -------------------------
 
 按照以下步骤提交 Pull Request（简称 PR）：
+
 **注意**
 
 本节介绍如何为 `master` 分支创建 PR。为其他分支创建 PR 的步骤与此类似。


### PR DESCRIPTION
1. 虽然Licence也对，但是为了与后面的链接保持一致，这里改成了License；
2. 补全OceaBase这个单词；
3. 增加一个换行，保持格式准确。