### PR TITLE
[创建 OceanBase 示例数据库 TPCC]章节，修改SQL逻辑执行问题几处

### DIFF
--- a/zh-CN/14.developer-guide/2.connect-to-oceanbase-database/3.create-oceanbase-sample-database-tpcc.md
+++ b/zh-CN/14.developer-guide/2.connect-to-oceanbase-database/3.create-oceanbase-sample-database-tpcc.md
@@ -1,8 +1,6 @@
 创建 OceanBase 示例数据库 TPCC 
 ============================================
 
-
-
 默认情况 OceanBase 没有创建示例数据库 TPCC，需要手动创建。示例数据库必须在业务租户下创建。有关示例数据库介绍请参考 [关于示例数据库 TPCC](../1.foreword/4.about-sample-database-tpcc.md)。 
 
 租户创建好后，需要创建相应的 Database 来存放示例数据库的对象，还要分配相应的用户和访问权限。
@@ -11,11 +9,6 @@
 -----------
 
 1. 通过 obclient 连接 MySQL 租户。
-
-   
-
-
-
 
 ```javascript
 #obclient -h192.168.0.0 -uroot@obmysql#obdemo -P2883 -p**1*** -A oceanbase
@@ -29,14 +22,7 @@ Server version: 5.6.25 OceanBase 2.2.20 (...) (Built Aug 10 2019 15:27:33)
 Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 ```
 
-
-
 2. 创建一个数据库。
-
-   
-
-
-
 
 ```javascript
 obclient> CREATE DATABASE tpccdb;
@@ -55,17 +41,13 @@ obclient> SHOW DATABASES;
 5 rows in set
 ```
 
-
-
 3. 创建一个用户并赋权。
 
-   
-
-
-
-
 ```javascript
-obclient> GRANT ALL PRIVILEGES ON tpccdb.* TO TPCC IDENTIFIED BY '**1***';
+obclient> GRANT ALL PRIVILEGES ON tpccdb.* TO tpcc IDENTIFIED BY '**1***';
+Query OK, 0 rows affected (0.02 sec)
+
+obclient> GRANT SELECT ON oceanbase.* TO 'tpcc';
 Query OK, 0 rows affected (0.02 sec)
 
 obclient> SHOW GRANTS FOR tpcc;
@@ -81,14 +63,7 @@ obclient> SHOW GRANTS FOR tpcc;
 obclient>
 ```
 
-
-
 4. 创建数据库对象
-
-   
-
-
-
 
 ```javascript
 obclient> USE tpccdb;


### PR DESCRIPTION
1. 去掉多余的空行；
2. mysql大小写敏感，将GRANT中的TPCC改为tpcc；
3. 增加语句 GRANT SELECT ON oceanbase.* TO 'tpcc';     没有这个语句下面的 SHOW 结果不会展示该权限。