### PR TITLE
Create 6.version-number-rules-of-oceanbase-database.md

### DIFF
--- a/zh-CN/1.users-guide/1.oceanbase-database/6.version-number-rules-of-oceanbase-database.md
+++ b/zh-CN/1.users-guide/1.oceanbase-database/6.version-number-rules-of-oceanbase-database.md
@@ -25,7 +25,7 @@ obclient> SELECT version();
 +--------------------+
 | version()          |
 +--------------------+
-| 3.1.2-OceanBase CE |
+| 3.1.4-OceanBase CE |
 +--------------------+
 1 row in set
 ```


### PR DESCRIPTION
 此处是3.1.4的文档，建议查看数据库版本由3.1.2改为3.1.4-OceanBase CE