### PR TITLE
Update 2.use-docker-to-deploy-oceanbase-database.md

### DIFF
--- a/zh-CN/1.users-guide/2.quick-start/2.use-docker-to-deploy-oceanbase-database.md
+++ b/zh-CN/1.users-guide/2.quick-start/2.use-docker-to-deploy-oceanbase-database.md
@@ -100,8 +100,8 @@ OceanBase Docker 镜像地址：<https://hub.docker.com/r/oceanbase/oceanbase-ce
   ➜  ~ docker logs obstandalone
   generate boot.yaml ...
   create boot dirs and deploy ob cluster ...
-  Package oceanbase-ce-3.1.3 is available.
-  install oceanbase-ce-3.1.3 for local ok
+  Package oceanbase-ce-3.1.4 is available.
+  install oceanbase-ce-3.1.4 for local ok
   Cluster param config check ok
   Open ssh connection ok
   Generate observer configuration ok
@@ -111,21 +111,21 @@ OceanBase Docker 镜像地址：<https://hub.docker.com/r/oceanbase/oceanbase-ce
   +--------------+---------+-----------------------+------------------------------------------+
   | Repository   | Version | Release               | Md5                                      |
   +--------------+---------+-----------------------+------------------------------------------+
-  | oceanbase-ce | 3.1.3   | 10000292022032916.el7 | eab08e5d473bd4884fdf2ac4d7dff6a329b68abe |
+  | oceanbase-ce | 3.1.4   | 10000292022032916.el7 | eab08e5d473bd4884fdf2ac4d7dff6a329b68abe |
   +--------------+---------+-----------------------+------------------------------------------+
   Repository integrity check ok
   Parameter check ok
   Open ssh connection ok
-  Remote oceanbase-ce-3.1.3-eab08e5d473bd4884fdf2ac4d7dff6a329b68abe repository install ok
-  Remote oceanbase-ce-3.1.3-eab08e5d473bd4884fdf2ac4d7dff6a329b68abe repository lib check !!
-  [WARN] 127.0.0.1 oceanbase-ce-3.1.3-eab08e5d473bd4884fdf2ac4d7dff6a329b68abe require: libmariadb.so.3
+  Remote oceanbase-ce-3.1.4-eab08e5d473bd4884fdf2ac4d7dff6a329b68abe repository install ok
+  Remote oceanbase-ce-3.1.4-eab08e5d473bd4884fdf2ac4d7dff6a329b68abe repository lib check !!
+  [WARN] 127.0.0.1 oceanbase-ce-3.1.4-eab08e5d473bd4884fdf2ac4d7dff6a329b68abe require: libmariadb.so.3
 
   Try to get lib-repository
-  Package oceanbase-ce-libs-3.1.3 is available.
-  install oceanbase-ce-libs-3.1.3 for local ok
-  Use oceanbase-ce-libs-3.1.3-c68c3aca8a1329a360fe5d65e1c3d4fa0f93f2d5 for oceanbase-ce-3.1.3-eab08e5d473bd4884fdf2ac4d7dff6a329b68abe
-  Remote oceanbase-ce-libs-3.1.3-c68c3aca8a1329a360fe5d65e1c3d4fa0f93f2d5 repository install ok
-  Remote oceanbase-ce-3.1.3-eab08e5d473bd4884fdf2ac4d7dff6a329b68abe repository lib check ok
+  Package oceanbase-ce-libs-3.1.4 is available.
+  install oceanbase-ce-libs-3.1.4 for local ok
+  Use oceanbase-ce-libs-3.1.3-c68c3aca8a1329a360fe5d65e1c3d4fa0f93f2d5 for oceanbase-ce-3.1.4-eab08e5d473bd4884fdf2ac4d7dff6a329b68abe
+  Remote oceanbase-ce-libs-3.1.4-c68c3aca8a1329a360fe5d65e1c3d4fa0f93f2d5 repository install ok
+  Remote oceanbase-ce-3.1.4-eab08e5d473bd4884fdf2ac4d7dff6a329b68abe repository lib check ok
   Cluster status check ok
   Initializes observer work home ok
   obcluster deployed


### PR DESCRIPTION
 此处的文档是介绍 V3.1.4 使用 Docker 安装OB 应该安装的版本是 oceanbase-ce-3.1.4 ，而文中使用的是oceanbase-ce-3.1.3，建议安装版本和文档版本对应起来。