### PR TITLE
Update 300.use-insert-into-select-statement-to-bypass-import-data.md

### DIFF
--- a/zh-CN/500.data-migration/1100.bypass-import/300.use-insert-into-select-statement-to-bypass-import-data.md
+++ b/zh-CN/500.data-migration/1100.bypass-import/300.use-insert-into-select-statement-to-bypass-import-data.md
@@ -43,6 +43,9 @@ obclient [test]> SELECT * FROM tbl2;
 +------+------+------+
 3 rows in set
 
+obclient [test]> set autocommit = on;
+Query OK, 0 rows affected (0.000 sec)
+
 obclient [test]> INSERT /*+ append enable_parallel_dml parallel(16) */ INTO tbl1 SELECT t2.col1,t2.col3 FROM tbl2 t2;
 Query OK, 3 rows affected
  Records: 3  Duplicates: 0  Warnings: 0


### PR DESCRIPTION
add `set autocommit = on` before execute direct insert, which can ensure no error raised even if user has set autocommit = off globally.

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
